### PR TITLE
RA-1921: Add "text" as a parameter type (RunReport)

### DIFF
--- a/omod/src/main/compass/sass/runReport.scss
+++ b/omod/src/main/compass/sass/runReport.scss
@@ -30,7 +30,6 @@ img.small {
   width: 24px;
   height: 24px;
 }
-
 .location-list {
   max-width: 350px;
 }

--- a/omod/src/main/compass/sass/runReport.scss
+++ b/omod/src/main/compass/sass/runReport.scss
@@ -30,6 +30,6 @@ img.small {
   width: 24px;
   height: 24px;
 }
-.location-list {
+.drop-down-list {
   max-width: 350px;
 }

--- a/omod/src/main/compass/sass/runReport.scss
+++ b/omod/src/main/compass/sass/runReport.scss
@@ -30,3 +30,7 @@ img.small {
   width: 24px;
   height: 24px;
 }
+
+.location-list {
+  max-width: 350px;
+}

--- a/omod/src/main/compass/sass/runReport.scss
+++ b/omod/src/main/compass/sass/runReport.scss
@@ -31,5 +31,5 @@ img.small {
   height: 24px;
 }
 .drop-down-list {
-  max-width: 350px;
+  width: 100%;
 }

--- a/omod/src/main/webapp/pages/runReport.gsp
+++ b/omod/src/main/webapp/pages/runReport.gsp
@@ -176,6 +176,11 @@ ${ ui.includeFragment("appui", "messages", [ codes: [
                                 label: it.labelOrName,
                                 initialValue: it.defaultValue ?: sessionContext.sessionLocation
                         ])}
+                    <% } else if (it.type == java.lang.String) { %>
+                        ${ ui.includeFragment("uicommons", "field/text", [
+                                formFieldName: "parameterValues[" + it.name + "]",
+                                label: it.labelOrName
+                        ])}
                     <% } else { %>
                         Unknown parameter type: ${ it.type }
                     <% } %>

--- a/omod/src/main/webapp/pages/runReport.gsp
+++ b/omod/src/main/webapp/pages/runReport.gsp
@@ -175,7 +175,7 @@ ${ ui.includeFragment("appui", "messages", [ codes: [
                                 formFieldName: "parameterValues[" + it.name + "]",
                                 label: it.labelOrName,
                                 initialValue: it.defaultValue ?: sessionContext.sessionLocation,
-                                classes: ["location-list"]
+                                classes: ["drop-down-list"]
                         ])}
                     <% } else if (it.type == java.lang.String) { %>
                         ${ ui.includeFragment("uicommons", "field/text", [

--- a/omod/src/main/webapp/pages/runReport.gsp
+++ b/omod/src/main/webapp/pages/runReport.gsp
@@ -174,7 +174,8 @@ ${ ui.includeFragment("appui", "messages", [ codes: [
                         ${ ui.includeFragment("uicommons", "field/location", [
                                 formFieldName: "parameterValues[" + it.name + "]",
                                 label: it.labelOrName,
-                                initialValue: it.defaultValue ?: sessionContext.sessionLocation
+                                initialValue: it.defaultValue ?: sessionContext.sessionLocation,
+                                classes: ["location-list"]
                         ])}
                     <% } else if (it.type == java.lang.String) { %>
                         ${ ui.includeFragment("uicommons", "field/text", [


### PR DESCRIPTION
#### Ticket:
https://issues.openmrs.org/browse/RA-1921

#### What I have done:
Currently reports that use RunReport as a template only support parameters of type:
- Date
- Location

The suggestion is to add Text as one of the types supported